### PR TITLE
chore(deps): bump https://github.com/beethub/receipt-api.git 

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[beethub/receipt-api](https://github.com/beethub/receipt-api.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: beethub
+  repo: receipt-api
+  url: https://github.com/beethub/receipt-api.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/beethub-receipt-api-sr.yaml
+++ b/repositories/templates/beethub-receipt-api-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: beethub
+    provider: github
+    repository: receipt-api
+  name: beethub-receipt-api
+spec:
+  description: Imported application for beethub/receipt-api
+  httpCloneURL: https://github.com/beethub/receipt-api.git
+  org: beethub
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: receipt-api
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/beethub/receipt-api.git


### PR DESCRIPTION
Update [beethub/receipt-api](https://github.com/beethub/receipt-api.git) 

Command run was `jx import --org=beethub --git-public=true`